### PR TITLE
Fixes for parameterized Dtypes

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.11 (2025-08-21)
+- fixed __eq__, __hash__, and __repr__ for types with parameters
+- import string length from sqlalchemy VARCHAR(n) type
+
 ## 0.3.10 (2025-08-21)
 - implemented String with max_length argument for SQL VARCHAR(n) generation
 - implemented Decimal with precision and scale arguments

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydiverse-common"
-version = "0.3.10"
+version = "0.3.11"
 description = "Common functionality shared between pydiverse libraries"
 authors = [
   { name = "QuantCo, Inc." },

--- a/tests/dtypes/test_dtype_sqlalchemy.py
+++ b/tests/dtypes/test_dtype_sqlalchemy.py
@@ -111,7 +111,7 @@ def test_all_types(type_):
     if type_ is pdc.List:
         type_obj = type_(pdc.Int64())
     elif type_ is pdc.Enum:
-        type_obj = type_("a", "b", "c")
+        type_obj = type_("a", "bbb", "cc")
     else:
         type_obj = type_()
     dst_type = type_obj.to_sql()
@@ -129,6 +129,6 @@ def test_all_types(type_):
         Float: Float64(),
         Int: Int64(),
         # there is no Enum
-        Enum: String(),
+        Enum: String(3),
     }
     assert back_type == acceptance_map.get(type_, type_obj)


### PR DESCRIPTION
- fixed __eq__, __hash__, and __repr__ for types with parameters
- import string length from sqlalchemy VARCHAR(n) type

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

# Checklist

- [x] Added a `docs/source/changelog.md` entry
