### PR TITLE
fix: Improve pandas hashing for object type columns

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.4.4 (202X-XX-XX)
+- Fix pandas hashing for edge cases
+
 ## 0.4.3 (2025-11-30)
 - drop support for python 3.10
 - add support for hashing pandas dataframes and arrow tables

--- a/src/pydiverse/common/util/hashing.py
+++ b/src/pydiverse/common/util/hashing.py
@@ -218,6 +218,7 @@ def stable_dataframe_hash(
 
     # 6) Hash subtleties of pandas DataFrame object type columns that are lost when converting
     # to pyarrow, e.g. columns mixing dates and datetimes, by hashing their CSV representation.
+    # See https://github.com/apache/arrow/issues/41896 for an example of such a conversion issue.
     if not isinstance(df, (pa.Table, pl.DataFrame)):
         import pandas as pd
 

--- a/src/pydiverse/common/util/hashing.py
+++ b/src/pydiverse/common/util/hashing.py
@@ -216,4 +216,16 @@ def stable_dataframe_hash(
     with ipc.RecordBatchStreamWriter(sink, t.schema, options=write_opts) as writer:
         writer.write_table(t, max_chunksize=t.num_rows)
 
-    return stable_hash(schema_hash, hashlib.sha256(sink.getvalue().to_pybytes()).hexdigest())
+    # 6) Hash subtleties of pandas DataFrame object type columns that are lost when converting
+    # to pyarrow, e.g. columns mixing dates and datetimes, by hashing their CSV representation.
+    if not isinstance(df, (pa.Table, pl.DataFrame)):
+        import pandas as pd
+
+        assert isinstance(df, pd.DataFrame), f"Dataframe of type {type(df)} not supported"
+
+        df_object = df.select_dtypes(include=["object"])
+        csv = df_object.to_csv()
+    else:
+        csv = ""
+
+    return stable_hash(schema_hash, hashlib.sha256(sink.getvalue().to_pybytes()).hexdigest(), csv)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -336,7 +336,6 @@ def test_hash_pandas():
 
 
 @pytest.mark.skipif(pd is None or pa is None, reason="requires pandas and pyarrow")
-@pytest.mark.xfail(reason="Pyarrow silently converts datetime to date: https://github.com/apache/arrow/issues/41896")
 def test_hash_pandas_datetime_edge_case():
     df_d = pd.DataFrame(
         {"a": [1, 2, 3], "b": [{"a": dt.date(2020, 1, 1)}, {"b": dt.date(2021, 2, 2)}, {"a": dt.date(2022, 3, 3)}]}
@@ -351,7 +350,6 @@ def test_hash_pandas_datetime_edge_case():
 
 
 @pytest.mark.skipif(pd is None or pa is None, reason="requires pandas and pyarrow")
-@pytest.mark.xfail(reason="Pyarrow silently converts datetime to date: https://github.com/apache/arrow/issues/41896")
 def test_hash_pandas_datetime_edge_case_2():
     df_d = pd.DataFrame({"a": [1, 2, 3], "b": [dt.date(2020, 1, 1), dt.date(2021, 2, 2), dt.date(2022, 3, 3)]})
     df_d_mixed = pd.DataFrame(

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -335,7 +335,7 @@ def test_hash_pandas():
         stable_dataframe_hash(df_f)
 
 
-@pytest.mark.skipif(pd is None or pa is None, reason="requires pandas and pyarrow")
+@pytest.mark.skipif(pd.DataFrame is None or pa.Table is None, reason="requires pandas and pyarrow")
 def test_hash_pandas_datetime_edge_case():
     # This test requires the conversion to CSV of pandas object type columns in the hashing function.
     # due to https://github.com/apache/arrow/issues/41896.
@@ -351,7 +351,7 @@ def test_hash_pandas_datetime_edge_case():
     check_df_hashes(df_d, df_d_mixed, use_polars=False)
 
 
-@pytest.mark.skipif(pd is None or pa is None, reason="requires pandas and pyarrow")
+@pytest.mark.skipif(pd.DataFrame is None or pa.Table is None, reason="requires pandas and pyarrow")
 def test_hash_pandas_datetime_edge_case_2():
     # This test requires the conversion to CSV of pandas object type columns in the hashing function.
     # due to https://github.com/apache/arrow/issues/41896.

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -337,6 +337,8 @@ def test_hash_pandas():
 
 @pytest.mark.skipif(pd is None or pa is None, reason="requires pandas and pyarrow")
 def test_hash_pandas_datetime_edge_case():
+    # This test requires the conversion to CSV of pandas object type columns in the hashing function.
+    # due to https://github.com/apache/arrow/issues/41896.
     df_d = pd.DataFrame(
         {"a": [1, 2, 3], "b": [{"a": dt.date(2020, 1, 1)}, {"b": dt.date(2021, 2, 2)}, {"a": dt.date(2022, 3, 3)}]}
     )
@@ -351,6 +353,8 @@ def test_hash_pandas_datetime_edge_case():
 
 @pytest.mark.skipif(pd is None or pa is None, reason="requires pandas and pyarrow")
 def test_hash_pandas_datetime_edge_case_2():
+    # This test requires the conversion to CSV of pandas object type columns in the hashing function.
+    # due to https://github.com/apache/arrow/issues/41896.
     df_d = pd.DataFrame({"a": [1, 2, 3], "b": [dt.date(2020, 1, 1), dt.date(2021, 2, 2), dt.date(2022, 3, 3)]})
     df_d_mixed = pd.DataFrame(
         {"a": [1, 2, 3], "b": [dt.date(2020, 1, 1), dt.date(2021, 2, 2), dt.datetime(2022, 3, 3, 1)]}


### PR DESCRIPTION
Fix hashing of pandas dataframes for edge cases, where the conversion to pyarrow did not distinguish between different `object` type values in pandas.

# Checklist

- [x] Added a `docs/source/changelog.md` entry
